### PR TITLE
docs: remove extra quote before "XOC"

### DIFF
--- a/pages/bvi/readme.mdx
+++ b/pages/bvi/readme.mdx
@@ -19,7 +19,7 @@ The core idea of BVI draws inspiration from the concept of <Link className='text
 
 The BVI system introduces two main types of incentives, ensuring both economic returns for participants and decentralized governance to avoid power centralization:
 
-- **Economic Incentives**: Accumulated GV can be exchanged for the native chain token, <Link className='text-primaryHue' showAnchorIcon href="/study/xoc">"XOC</Link>, providing users with tangible financial rewards.
+- **Economic Incentives**: Accumulated GV can be exchanged for the native chain token, <Link className='text-primaryHue' showAnchorIcon href="/study/xoc">XOC</Link>, providing users with tangible financial rewards.
 - **Governance Incentives**: GV can also be converted into voting power (GVOTING), allowing users to take part in major platform decisions and contribute to ecosystem optimization and resource allocation.
 
 ### 2.3 Free Identity and Open Organization

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "xone-docs-dev"
+name = "xone-docs"
 compatibility_date = "2025-03-27"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = ".vercel/output/static"


### PR DESCRIPTION
## Description
<img width="914" height="149" alt="Снимок экрана 2025-09-05 в 14 31 25" src="https://github.com/user-attachments/assets/91ff9f34-991e-4864-9517-07a92dd47b14" />

just got rid of a stray `"` before `"XOC"`

