### PR TITLE
docs: fix typo in name from "Torn" to "Tron"

### DIFF
--- a/pages/study/donate/guide/usdh.mdx
+++ b/pages/study/donate/guide/usdh.mdx
@@ -48,7 +48,7 @@ This guide is designed to help you successfully complete the USDH swap process b
 
 1. On the swap page, you can view detailed information about USDH, including the exchange rate and swap rules. Make sure you understand the relevant terms and conditions to make an informed decision.
 
-2. USDH currently supports swaps on three mainnets: Ethereum, Torn, and BnbChain. Solana is not yet available. The corresponding contract information is as follows:
+2. USDH currently supports swaps on three mainnets: Ethereum, Tron, and BnbChain. Solana is not yet available. The corresponding contract information is as follows:
 
 <Table>
   <thead>


### PR DESCRIPTION
## Description

<img width="940" height="156" alt="Снимок экрана 2025-09-07 в 13 19 42" src="https://github.com/user-attachments/assets/f7a00a82-46d6-4929-9095-e1bc4a5bbfa5" />
fixed the typo, it should say **Tron** now.
